### PR TITLE
Use local site and Quarto sources for search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /data/
 /*_cache/
 /*_files/
+node_modules/

--- a/api/search_repo_qps1.js
+++ b/api/search_repo_qps1.js
@@ -1,18 +1,18 @@
-import path from "path";
-import { searchInRepo } from "../lib/searchInRepo.js";
+const path = require('path');
+const { searchInRepo } = require('../lib/searchInRepo');
 
-export default async function handler(req, res) {
-  const params = req.method === "POST" ? { ...req.body, ...req.query } : req.query;
+module.exports = async (req, res) => {
+  const params = req.method === 'POST' ? { ...req.body, ...req.query } : req.query;
   const { query, top_k = 5 } = params;
-  const path_glob = ["*.qmd"]; // root-only
+  const path_glob = ['**/*.qmd'];
 
-  if (!query || typeof query !== "string") {
-    return res.status(400).json({ error: "query (string) is required" });
+  if (!query || typeof query !== 'string') {
+    return res.status(400).json({ error: 'query (string) is required' });
   }
 
   try {
     const results = await searchInRepo({
-      repoPath: path.join(process.cwd(), "public", "qps1"),
+      repoPath: path.join(process.cwd(), 'quarto'),
       query,
       top_k: Number(top_k),
       path_glob,
@@ -22,5 +22,5 @@ export default async function handler(req, res) {
     console.error(err);
     res.status(500).json({ error: err.message });
   }
-}
+};
 

--- a/lib/searchInRepo.js
+++ b/lib/searchInRepo.js
@@ -1,30 +1,31 @@
-import fs from "fs";
-import path from "path";
-import fg from "fast-glob";
-import { spawnSync } from "child_process";
+const fs = require('fs');
+const path = require('path');
+const fg = require('fast-glob');
+const { spawnSync } = require('child_process');
 
-export async function searchInRepo({ repoPath, query, top_k, path_glob }) {
+async function searchInRepo({ repoPath, query, top_k, path_glob }) {
   if (!fs.existsSync(repoPath)) {
     throw new Error(`Repo path not found: ${repoPath}`);
   }
 
-  const files = await fg(path_glob, { cwd: repoPath, absolute: true, deep: 1 });
+  const files = await fg(path_glob, { cwd: repoPath, absolute: true });
   const results = [];
 
   files.forEach((file) => {
-    const rg = spawnSync("rg", ["--json", query, file], { encoding: "utf8" });
+    const rg = spawnSync('rg', ['--json', query, file], { encoding: 'utf8' });
     if (rg.stdout) {
       rg.stdout
-        .split("\n")
+        .split('\n')
         .filter(Boolean)
         .forEach((line) => {
           try {
             const obj = JSON.parse(line);
-            if (obj.type === "match") {
+            if (obj.type === 'match') {
+              const rel = path.relative(process.cwd(), obj.data.path.text).replace(/\\/g, '/');
               results.push({
-                path: path.relative(repoPath, obj.data.path.text),
-                url: `https://github.com/brentonk/qps1/blob/main/${path.relative(repoPath, obj.data.path.text)}`,
-                commit_sha: getCommitSha(repoPath),
+                path: rel,
+                url: `https://github.com/brentonk/qps1/blob/main/${rel}`,
+                commit_sha: getCommitSha(process.cwd()),
                 snippet: obj.data.lines.text.trim(),
                 score: 1.0,
                 language: detectLanguage(obj.data.path.text),
@@ -40,19 +41,21 @@ export async function searchInRepo({ repoPath, query, top_k, path_glob }) {
 }
 
 function getCommitSha(repoPath) {
-  const git = spawnSync("git", ["-C", repoPath, "rev-parse", "HEAD"], { encoding: "utf8" });
+  const git = spawnSync('git', ['-C', repoPath, 'rev-parse', 'HEAD'], { encoding: 'utf8' });
   return git.stdout.trim();
 }
 
 function detectLanguage(filePath) {
   const ext = path.extname(filePath).toLowerCase();
-  if (ext === ".qmd" || ext === ".md") return "markdown";
-  if (ext === ".r" || ext === ".rmd") return "r";
-  return "";
+  if (ext === '.qmd' || ext === '.md') return 'markdown';
+  if (ext === '.r' || ext === '.rmd') return 'r';
+  return '';
 }
 
 function extractChunkLabel(line) {
   const match = line.match(/\{#(.*?)\}/);
   return match ? match[1] : null;
 }
+
+module.exports = { searchInRepo };
 

--- a/lib/searchIndex.js
+++ b/lib/searchIndex.js
@@ -1,17 +1,17 @@
 // Shared index + cache for Quarto search.json
-// Works in Vercel serverless (module-level cache persists per instance)
+// Reads from local site/search.json instead of fetching over HTTP
 
+const fs = require('fs');
+const path = require('path');
 const MiniSearch = require('minisearch');
 
-const BASE = 'https://bkenkel.com/qps1/';
-const INDEX_URL = `${BASE}search.json`;
+const BASE = '/';
+const INDEX_PATH = path.join(process.cwd(), 'site', 'search.json');
 
 let cache = {
-  etag: null,
-  lastModified: null,
-  lastFetchAt: 0,
+  mtimeMs: 0,
   docs: [],
-  mini: null
+  mini: null,
 };
 
 function buildIndex(docs) {
@@ -22,39 +22,21 @@ function buildIndex(docs) {
     searchOptions: {
       boost: { title: 2, section: 1.5, text: 1 },
       prefix: true,
-      fuzzy: 0.2
-    }
+      fuzzy: 0.2,
+    },
   });
   mini.addAll(docs);
   return mini;
 }
 
 async function ensureIndex(force = false) {
-  const now = Date.now();
-  const STALE_MS = 6 * 60 * 60 * 1000; // 6h cache window
+  const stats = fs.statSync(INDEX_PATH);
+  if (!force && cache.mini && cache.mtimeMs === stats.mtimeMs) return;
 
-  if (!force && cache.mini && now - cache.lastFetchAt < STALE_MS) return;
-
-  const headers = {};
-  if (cache.etag) headers['If-None-Match'] = cache.etag;
-  if (cache.lastModified) headers['If-Modified-Since'] = cache.lastModified;
-
-  const res = await fetch(INDEX_URL, { headers });
-  if (res.status === 304) {
-    cache.lastFetchAt = now;
-    return;
-  }
-  if (!res.ok) {
-    if (!cache.mini) throw new Error(`Failed to fetch ${INDEX_URL}: ${res.status}`);
-    // keep old index on transient failure
-    return;
-  }
-
-  cache.etag = res.headers.get('etag');
-  cache.lastModified = res.headers.get('last-modified');
-  cache.docs = await res.json();
+  const raw = fs.readFileSync(INDEX_PATH, 'utf8');
+  cache.docs = JSON.parse(raw);
   cache.mini = buildIndex(cache.docs);
-  cache.lastFetchAt = now;
+  cache.mtimeMs = stats.mtimeMs;
 }
 
 function lectureLabelFromHref(href = '') {
@@ -75,7 +57,7 @@ function decorate(doc, score = 0) {
     slide_number: null,
     snippet,
     score,
-    updated_at: new Date(cache.lastFetchAt).toISOString()
+    updated_at: new Date(cache.mtimeMs).toISOString(),
   };
 }
 
@@ -99,9 +81,9 @@ async function searchIndex(query, topK = 5, filters = null) {
   const hits = cache.mini.search(query, {
     prefix: true,
     fuzzy: 0.2,
-    filter: (doc) => passesFilters(doc, filters)
+    filter: (doc) => passesFilters(doc, filters),
   });
-  return hits.slice(0, maxK).map(h => decorate(h, h.score || 0));
+  return hits.slice(0, maxK).map((h) => decorate(h, h.score || 0));
 }
 
 module.exports = { ensureIndex, searchIndex, decorate, BASE };


### PR DESCRIPTION
## Summary
- Build search index from local `site/search.json` instead of fetching over HTTP.
- Recursively search Quarto sources under `quarto/` and expose through API.
- Ignore `node_modules` directory.

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689e48d124e0832fb51fbfb27d9e99ff