### PR TITLE
Bundle ripgrep binary for repo search

### DIFF
--- a/lib/searchInRepo.js
+++ b/lib/searchInRepo.js
@@ -10,30 +10,60 @@ async function searchInRepo({ repoPath, query, top_k, path_glob }) {
 
   const files = await fg(path_glob, { cwd: repoPath, absolute: true });
   const results = [];
+  const commitSha = getCommitSha(process.cwd());
+
+  let rgCmd = null;
+  try {
+    const { rgPath } = require('@vscode/ripgrep');
+    rgCmd = rgPath;
+  } catch {}
 
   files.forEach((file) => {
-    const rg = spawnSync('rg', ['--json', query, file], { encoding: 'utf8' });
-    if (rg.stdout) {
-      rg.stdout
-        .split('\n')
-        .filter(Boolean)
-        .forEach((line) => {
-          try {
-            const obj = JSON.parse(line);
-            if (obj.type === 'match') {
-              const rel = path.relative(process.cwd(), obj.data.path.text).replace(/\\/g, '/');
-              results.push({
-                path: rel,
-                url: `https://github.com/brentonk/qps1/blob/main/${rel}`,
-                commit_sha: getCommitSha(process.cwd()),
-                snippet: obj.data.lines.text.trim(),
-                score: 1.0,
-                language: detectLanguage(obj.data.path.text),
-                chunk_label: extractChunkLabel(obj.data.lines.text),
-              });
-            }
-          } catch {}
-        });
+    let matched = false;
+
+    if (rgCmd) {
+      const rg = spawnSync(rgCmd, ['--json', query, file], { encoding: 'utf8' });
+      if (!rg.error && rg.stdout) {
+        rg.stdout
+          .split('\n')
+          .filter(Boolean)
+          .forEach((line) => {
+            try {
+              const obj = JSON.parse(line);
+              if (obj.type === 'match') {
+                const rel = path.relative(process.cwd(), obj.data.path.text).replace(/\\/g, '/');
+                results.push({
+                  path: rel,
+                  url: `https://github.com/brentonk/qps1/blob/main/${rel}`,
+                  commit_sha: commitSha,
+                  snippet: obj.data.lines.text.trim(),
+                  score: 1.0,
+                  language: detectLanguage(obj.data.path.text),
+                  chunk_label: extractChunkLabel(obj.data.lines.text),
+                });
+              }
+            } catch {}
+          });
+        matched = true;
+      }
+    }
+
+    if (!matched) {
+      const content = fs.readFileSync(file, 'utf8');
+      content.split('\n').forEach((line) => {
+        if (line.includes(query)) {
+          const rel = path.relative(process.cwd(), file).replace(/\\/g, '/');
+          results.push({
+            path: rel,
+            url: `https://github.com/brentonk/qps1/blob/main/${rel}`,
+            commit_sha: commitSha,
+            snippet: line.trim(),
+            score: 1.0,
+            language: detectLanguage(file),
+            chunk_label: extractChunkLabel(line),
+          });
+        }
+      });
     }
   });
 
@@ -42,7 +72,7 @@ async function searchInRepo({ repoPath, query, top_k, path_glob }) {
 
 function getCommitSha(repoPath) {
   const git = spawnSync('git', ['-C', repoPath, 'rev-parse', 'HEAD'], { encoding: 'utf8' });
-  return git.stdout.trim();
+  return git.stdout ? git.stdout.trim() : '';
 }
 
 function detectLanguage(filePath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "qps1",
       "version": "1.0.0",
       "dependencies": {
+        "@vscode/ripgrep": "^1.15.14",
         "fast-glob": "^3.3.3",
         "minisearch": "^7.1.0"
       },
@@ -50,6 +51,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.15.14",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.14.tgz",
+      "integrity": "sha512-/G1UJPYlm+trBWQ6cMO3sv6b8D1+G16WaJH1/DSqw32JOVlzgZbLkDxRyzIpTpv30AcYGMkCf5tUqGlW6HbDWw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.2",
+        "proxy-from-env": "^1.1.0",
+        "yauzl": "^2.9.2"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -60,6 +82,32 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/fast-glob": {
@@ -87,6 +135,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -109,6 +166,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/is-extglob": {
@@ -169,6 +239,18 @@
       "integrity": "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -180,6 +262,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -244,6 +332,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "minisearch": "^7.1.0",
-    "fast-glob": "^3.3.3"
+    "@vscode/ripgrep": "^1.15.14",
+    "fast-glob": "^3.3.3",
+    "minisearch": "^7.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `@vscode/ripgrep` dependency so the `rg` binary is available in Vercel
- use the bundled ripgrep path in `searchInRepo`
- fall back to a built-in JS search when the ripgrep binary is unavailable

## Testing
- `npm ci`
- `npm test` *(fails: Missing script "test")*
- `node -e "(async () => { const { searchInRepo } = require('./lib/searchInRepo'); const res = await searchInRepo({ repoPath: process.cwd(), query: 'searchInRepo', top_k: 1, path_glob:['lib/searchInRepo.js']}); console.log(res); })();"`
- `mv node_modules/@vscode node_modules/@vscode_tmp && node -e "(async () => { const { searchInRepo } = require('./lib/searchInRepo'); const res = await searchInRepo({ repoPath: process.cwd(), query: 'searchInRepo', top_k: 1, path_glob:['lib/searchInRepo.js']}); console.log(res); })();" && mv node_modules/@vscode_tmp node_modules/@vscode`


------
https://chatgpt.com/codex/tasks/task_e_689e5e936c44832f8002cfc786b41ab2